### PR TITLE
Fix theme persistence, keep toggle visible

### DIFF
--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -6,6 +6,7 @@ import styles from "./theme-toggle.module.css";
 export default function ThemeToggle() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
   const [mounted, setMounted] = useState(false);
+  const [userPref, setUserPref] = useState(false);
 
   // Applique le thème à l'hydratation (SSR friendly)
   useEffect(() => {
@@ -21,6 +22,8 @@ export default function ThemeToggle() {
     }
   }, []);
 
+  // userPref intentionally omitted from deps to only persist after explicit toggle
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!mounted) return;
     document.body.classList.add("transition-enabled");
@@ -29,7 +32,7 @@ export default function ThemeToggle() {
     } else {
       document.body.removeAttribute("data-theme");
     }
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && userPref) {
       localStorage.setItem("theme", theme);
     }
     const t = setTimeout(() => {
@@ -38,7 +41,10 @@ export default function ThemeToggle() {
     return () => clearTimeout(t);
   }, [theme, mounted]);
 
-  const toggle = () => setTheme((t) => (t === "dark" ? "light" : "dark"));
+  const toggle = () => {
+    setUserPref(true);
+    setTheme((t) => (t === "dark" ? "light" : "dark"));
+  };
 
   // On cache l’icône côté serveur pour éviter le “flicker”
   if (!mounted) return <span className={styles.themeToggle} />;

--- a/app/components/header.module.css
+++ b/app/components/header.module.css
@@ -15,7 +15,7 @@ header.cover {
   top: 0;
   left: 0;
   width: 100vw;
-  z-index: 200;
+  z-index: 260;
   display: flex;
   align-items: center;
   justify-content: flex-end;

--- a/app/components/theme-toggle.module.css
+++ b/app/components/theme-toggle.module.css
@@ -20,7 +20,7 @@
   align-items: center;
   justify-content: center;
   padding: 8px 11px 8px 11px; /* Top Right Bottom Left */
-  margin-right: 4px;
+  margin: 22px 4px 0 0;
   border-radius: 50%;
   transition: background 0.2s, filter 0.2s;
   height: 44px;
@@ -53,4 +53,10 @@
 .themeToggle:focus .icon {
   transform: rotate(26deg) scale(1.1);
   color: var(--color-header-link-hover, #ffd700);
+}
+
+@media (max-width: 700px) {
+  .themeToggle {
+    margin: 13px 4px 0 0;
+  }
 }


### PR DESCRIPTION
## Summary
- raise header nav z-index so theme toggle stays visible
- only save theme when user toggles it
- explain omitting `userPref` from `useEffect` dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*